### PR TITLE
First pass at the spade edge protocol

### DIFF
--- a/spade/event.go
+++ b/spade/event.go
@@ -1,0 +1,39 @@
+package spade
+
+import (
+	"encoding/json"
+	"net"
+	"time"
+)
+
+// This might be a really bad idea, perhaps the version should be
+// defined in the clients of this code, as it current stands we cannot
+// move one without the other. Recommended ways to solve this sort of
+// thing in Protobuf and Thirft is to have your namespace dicate version
+const PROTOCOL_VERSION = 2
+
+type Event struct {
+	ReceivedAt time.Time `json:receivedAt`
+	ClientIp   net.IP    `json:clientIp,string`
+	Uuid       string    `json:uuid`
+	Data       string    `json:data`
+	Version    int       `json:recordversion`
+}
+
+func NewEvent(receivedAt time.Time, clientIp net.IP, uuid, data string) *Event {
+	return &Event{
+		ReceivedAt: receivedAt,
+		ClientIp:   clientIp,
+		Uuid:       uuid,
+		Data:       data,
+		Version:    PROTOCOL_VERSION,
+	}
+}
+
+func Marshal(src *Event) ([]byte, error) {
+	return json.Marshal(src)
+}
+
+func Unmarshal(b []byte, dst *Event) error {
+	return json.Unmarshal(b, &dst)
+}

--- a/spade/event.go
+++ b/spade/event.go
@@ -13,11 +13,11 @@ import (
 const PROTOCOL_VERSION = 2
 
 type Event struct {
-	ReceivedAt time.Time `json:receivedAt`
-	ClientIp   net.IP    `json:clientIp,string`
-	Uuid       string    `json:uuid`
-	Data       string    `json:data`
-	Version    int       `json:recordversion`
+	ReceivedAt time.Time `json:"receivedAt"`
+	ClientIp   net.IP    `json:"clientIp"`
+	Uuid       string    `json:"uuid"`
+	Data       string    `json:"data"`
+	Version    int       `json:"recordversion"`
 }
 
 func NewEvent(receivedAt time.Time, clientIp net.IP, uuid, data string) *Event {

--- a/spade/event_test.go
+++ b/spade/event_test.go
@@ -1,0 +1,66 @@
+package spade
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+)
+
+var exEvent = NewEvent(
+	time.Unix(1397768380, 0),
+	net.ParseIP("222.222.222.222"),
+	"1",
+	"blag",
+)
+
+// These exist to ensure that the impact of proxying the chosen
+// serialization method is negligible.
+//
+// Current performance behaviour suggests these pose no significant
+// issue:
+// $ go test -bench=. github.com/twitchscience/scoop_protocol/spade
+//
+// Benchmark_Marshal        500000      4495 ns/op
+// Benchmark_Unmarshal      500000      6245 ns/op
+// Benchmark_MarshalJSON    500000      4547 ns/op
+// Benchmark_UnmarshalJSON  500000      6383 ns/op
+
+var byteHolder []byte
+var eventHolder Event
+
+func Benchmark_Marshal(b *testing.B) {
+	var d []byte
+	for i := 0; i < b.N; i++ {
+		d, _ = Marshal(exEvent)
+	}
+	byteHolder = d
+}
+
+func Benchmark_Unmarshal(b *testing.B) {
+	var e Event
+	var d []byte
+	d, _ = Marshal(exEvent)
+	for i := 0; i < b.N; i++ {
+		Unmarshal(d, &e)
+	}
+	eventHolder = e
+}
+
+func Benchmark_MarshalJSON(b *testing.B) {
+	var d []byte
+	for i := 0; i < b.N; i++ {
+		d, _ = json.Marshal(exEvent)
+	}
+	byteHolder = d
+}
+
+func Benchmark_UnmarshalJSON(b *testing.B) {
+	var e Event
+	var d []byte
+	d, _ = Marshal(exEvent)
+	for i := 0; i < b.N; i++ {
+		json.Unmarshal(d, &e)
+	}
+	eventHolder = e
+}

--- a/spade/event_test.go
+++ b/spade/event_test.go
@@ -1,17 +1,29 @@
 package spade
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
+	"log"
 	"net"
 	"testing"
 	"time"
 )
 
+func randomString(n int) string {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		log.Fatal("while generating random string:", err)
+	}
+	return base64.URLEncoding.EncodeToString(b)
+}
+
 var exEvent = NewEvent(
 	time.Unix(1397768380, 0),
 	net.ParseIP("222.222.222.222"),
 	"1",
-	"blag",
+	randomString(2048),
 )
 
 // These exist to ensure that the impact of proxying the chosen
@@ -19,12 +31,13 @@ var exEvent = NewEvent(
 //
 // Current performance behaviour suggests these pose no significant
 // issue:
+
 // $ go test -bench=. github.com/twitchscience/scoop_protocol/spade
 //
-// Benchmark_Marshal        500000      4495 ns/op
-// Benchmark_Unmarshal      500000      6245 ns/op
-// Benchmark_MarshalJSON    500000      4547 ns/op
-// Benchmark_UnmarshalJSON  500000      6383 ns/op
+// Benchmark_Marshal       200000     14846 ns/op
+// Benchmark_Unmarshal      50000     47529 ns/op
+// Benchmark_MarshalJSON   200000     14743 ns/op
+// Benchmark_UnmarshalJSON  50000     47391 ns/op
 
 var byteHolder []byte
 var eventHolder Event


### PR DESCRIPTION
A shim to represent / serialize and / deserialize our events, to be used by the edge when communicating with the processor tier.