### PR TITLE
Add json struct for better struct separation in rs_ingester

### DIFF
--- a/scoop_protocol/scoop_protocol.go
+++ b/scoop_protocol/scoop_protocol.go
@@ -43,9 +43,9 @@ type LoadCheckResponse struct {
 	ManifestURL string
 }
 
-//Scoop healthcheck for ingester healthcheck json unmarshal
-type ConnError struct {
-	RedshiftDBConnError, IngesterDBConnError *string
+type ScoopHealthCheck struct {
+	RedshiftDBConnError *string
+	IngesterDBConnError *string
 }
 
 type LoadStatus string

--- a/scoop_protocol/scoop_protocol.go
+++ b/scoop_protocol/scoop_protocol.go
@@ -43,6 +43,11 @@ type LoadCheckResponse struct {
 	ManifestURL string
 }
 
+//Scoop healthcheck for ingester healthcheck json unmarshal
+type ConnError struct {
+	RedshiftDBConnError, IngesterDBConnError *string
+}
+
 type LoadStatus string
 
 const (


### PR DESCRIPTION
I needed to add a struct to scoop_protocol so that I wouldn't have it sitting in multiple repos as individual structs.  